### PR TITLE
Simplify the interface

### DIFF
--- a/.github/linters/.pylintrc
+++ b/.github/linters/.pylintrc
@@ -1,7 +1,0 @@
-# SPDX-FileCopyrightText: Copyright 2020-present Open Networking Foundation.
-# SPDX-License-Identifier: Apache-2.0
-[MESSAGES CONTROL]
-disable = C0330, C0326, F405
-
-[format]
-max-line-length = 88

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ SWITCH_ADDR?=10.128.13.29
 TEST?=int_single_flow
 TREX_CONFIG:=$(current_dir)/trex-configs
 TREX_SCRIPTS:=$(current_dir)/trex-scripts
-EXTRA_TEST_ARGS?=
 
 default:
 	@echo "Nothing here"
@@ -29,16 +28,6 @@ set-up-dev-env: .venv
 	@cp -r trex_python/* .venv/lib/python3.8/site-packages/
 	@rm -rf trex_python
 	@docker rm set_up_dev_env
-
-run-test:
-	@docker run --rm \
-						-v $(current_dir)/trex-configs:/workspace/trex-configs \
-						-v $(current_dir)/trex-scripts:/workspace/trex-scripts \
-						-v $(current_dir)/tmp:/tmp \
-						$(IMAGE) \
-						--server $(SERVER_ADDR) \
-						--trex-config /workspace/trex-configs/$(TEST).yaml \
-						$(EXTRA_TEST_ARGS) $(TEST)
 
 dev:
 	@docker run --rm \

--- a/README.md
+++ b/README.md
@@ -116,18 +116,15 @@ For INT test, remember to add INT watch list rules via [ONOS web UI](onos-ui).
 To run a test, use following command:
 
 ```bash
-make run-test SERVER_ADDR="10.128.13.27" TEST="int_single_flow" EXTRA_TEST_ARGS="--duration 10"
+./run-test.sh -h -s [server IP address] [test name] [test params]
 ```
 
-Parameters for this make target:
+Parameters for this script
 
-- SERVER_ADDR: the Trex daemon server address
-- TEST: the test profile name
-- EXTRA_TEST_ARGS: extra arguments that pass to the test
-  - --duration: the test duration, unit is second
-  - --force-restart: force restart the Trex server before new test
-  - --mult: Traffic multiplier, for example: 100kpps, 10gbps, 87%
-  - --keep-running: Keep Trex server running after test, the Trex server will stop after each test by default.
+- -s: the Trex daemon server address
+- -h: print help text
+- test name: the test in trex-script/tests/
+- test params: extra arguments that pass to the test
 
 ## Develop a new test
 

--- a/run-test.sh
+++ b/run-test.sh
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright 2020-present Open Networking Foundation.
 # SPDX-License-Identifier: Apache-2.0
 
-set -xe
+set -e
 
 function help() {
   echo "Usage $0 -h -s [server IP address] [test name] [test params]"
@@ -24,7 +24,7 @@ while (( "$#" )); do
       help
       exit 0
       ;;
-    -*|--*|--*=*)
+    -*)
       echo "Unkonwon flag $1"
       help
       exit 1
@@ -33,7 +33,7 @@ while (( "$#" )); do
       # Test and test parameters
       TEST=$1
       shift 1
-      TEST_FLAGS=$@
+      TEST_FLAGS=$*
       break
   esac
 done
@@ -48,12 +48,13 @@ if [ -z "$TEST" ]; then
   exit 1
 fi
 
+# shellcheck disable=SC2086
 docker run --rm \
-           -v ${DIR}/trex-configs:/workspace/trex-configs \
-           -v ${DIR}/trex-scripts:/workspace/trex-scripts \
-           -v ${DIR}/tmp:/tmp \
+           -v "${DIR}/trex-configs:/workspace/trex-configs" \
+           -v "${DIR}/trex-scripts:/workspace/trex-scripts" \
+           -v "${DIR}/tmp:/tmp" \
            -w /workspace \
-           ${IMAGE} \
-           --server ${SERVER_ADDR} \
-           --trex-config /workspace/trex-configs/${TEST}.yaml \
+           "${IMAGE}" \
+           --server "${SERVER_ADDR}" \
+           --trex-config "/workspace/trex-configs/${TEST}.yaml" \
            ${TEST} ${TEST_FLAGS}

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright 2020-present Open Networking Foundation.
+# SPDX-License-Identifier: Apache-2.0
+
+set -xe
+
+function help() {
+  echo "Usage $0 -h -s [server IP address] [test name] [test params]"
+}
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SERVER_ADDR="10.128.13.27"
+TEST=""
+IMAGE="fabric-line-rate-test:0.0.1"
+TEST_FLAGS=""
+
+while (( "$#" )); do
+  case "$1" in
+    -s)
+      SERVER_ADDR=$2
+      shift 2
+      ;;
+    -h|--help)
+      help
+      exit 0
+      ;;
+    -*|--*|--*=*)
+      echo "Unkonwon flag $1"
+      help
+      exit 1
+      ;;
+    *)
+      # Test and test parameters
+      TEST=$1
+      shift 1
+      TEST_FLAGS=$@
+      break
+  esac
+done
+
+if [ -z "$SERVER_ADDR" ]; then
+  echo "Server address cannot be empty"
+  exit 1
+fi
+
+if [ -z "$TEST" ]; then
+  echo "Test name cannot be empty"
+  exit 1
+fi
+
+docker run --rm \
+           -v ${DIR}/trex-configs:/workspace/trex-configs \
+           -v ${DIR}/trex-scripts:/workspace/trex-scripts \
+           -v ${DIR}/tmp:/tmp \
+           -w /workspace \
+           ${IMAGE} \
+           --server ${SERVER_ADDR} \
+           --trex-config /workspace/trex-configs/${TEST}.yaml \
+           ${TEST} ${TEST_FLAGS}

--- a/trex-scripts/lib/base_test.py
+++ b/trex-scripts/lib/base_test.py
@@ -1,70 +1,54 @@
 # SPDX-FileCopyrightText: Copyright 2020-present Open Networking Foundation.
 # SPDX-License-Identifier: Apache-2.0
 from abc import ABC, abstractclassmethod, abstractmethod
+from argparse import ArgumentParser
 
 from trex.astf.api import ASTFClient
 from trex_stl_lib.api import STLClient
 
 
 class BaseTest(ABC):
-    duration: int
-    mult: str
-    test_args: dict
-
-    def __init__(
-        self, duration: int = 1, mult: str = "1pps", test_args: dict = {}
-    ) -> None:
+    @abstractmethod
+    def start(self, args: dict = {}) -> None:
         """
-        Create and initialize a base test
+        Start the test
 
         :parameters:
-            duration: int
-                The duration of the traffic (seconds).
-                Default is 1 second.
-            mult: str
-                Multiplier in a form of pps, bps, or line util in %.
-                Default is 1pps.
-        """
-        self.duration = duration
-        self.mult = mult
-        self.test_args = test_args
-
-    @abstractmethod
-    def start(self) -> None:
-        """
-        Start the traffic
+            args: dict
+                The test arguments
         """
         pass
 
     @abstractclassmethod
     def test_type(cls) -> str:
+        """
+        Get test type, for example: stateless or stateful
+        """
         return None
+
+    @classmethod
+    def setup_subparser(cls, parser: ArgumentParser) -> None:
+        """
+        Initialize the subparser
+
+        :parameters:
+            parser: ArgumentParser
+                The parent argument parser
+        """
+        pass
 
 
 class StatelessTest(BaseTest):
     client: STLClient
 
-    def __init__(
-        self,
-        client: STLClient,
-        duration: int = 1,
-        mult: str = "1pps",
-        test_args: dict = {},
-    ) -> None:
+    def __init__(self, client: STLClient) -> None:
         """
         Create and initialize a test
 
         :parameters:
             client: STLClient
                 The Trex statelesss client
-            duration: int
-                The duration of the traffic (seconds).
-                Default is 1 second.
-            mult: str
-                Multiplier in a form of pps, bps, or line util in %.
-                Default is 1pps.
         """
-        super().__init__(duration, mult, test_args)
         self.client = client
 
     @classmethod
@@ -75,29 +59,16 @@ class StatelessTest(BaseTest):
 class StatefulTest(BaseTest):
     client: ASTFClient
 
-    def __init__(
-        self,
-        client: ASTFClient,
-        duration: int = 1,
-        mult: str = "1pps",
-        test_args: dict = {},
-    ) -> None:
+    def __init__(self, client: ASTFClient) -> None:
         """
         Create and initialize a test
 
         :parameters:
             client: ASTFClient
                 The Trex advance stateful client
-            duration: int
-                The duration of the traffic (seconds).
-                Default is 1 second.
-            mult: str
-                Multiplier in a form of pps, bps, or line util in %.
-                Default is 1pps.
         """
-        super().__init__(duration, mult, test_args)
         self.client = client
 
     @classmethod
     def test_type(cls) -> str:
-        return "stateful"
+        return "astf"


### PR DESCRIPTION
Brfore we have to put lots of custom flags to the parser, and we may also
need to parse the argument in some tests

The new approach is to use the subparser, so tests can have different flag
definition.

 - Use subparser to parse custom flags
 - Move run-test from Makefile to a script so we can provide more general
   way for user to use it
 - remove pylintrc file (Left from previous patches)