### PR TITLE
Support multiple remote pcap files

### DIFF
--- a/trex-scripts/tests/remote_pcap.py
+++ b/trex-scripts/tests/remote_pcap.py
@@ -33,6 +33,7 @@ class RemotePcap(StatelessTest):
         parser.add_argument(
             "--speed-multiplier", type=float, help="The speed multiplier", default=1
         )
+        parser.add_argument("--duration", type=float, help="Test duration", default=-1)
         parser.add_argument(
             "--print-reports",
             action="store_true",
@@ -58,9 +59,11 @@ class RemotePcap(StatelessTest):
             "Starting traffic, speedup: %f", args.speed_multiplier,
         )
         for remote_pcap_file in args.remote_pcap_files:
+            duration = args.duration / len(args.remote_pcap_files)
             self.client.push_remote(
                 args.remote_pcap_file_dir + remote_pcap_file,
                 speedup=args.speed_multiplier,
+                duration=duration,
                 ports=SENDER_PORTS,
             )
 

--- a/trex-scripts/tests/remote_pcap.py
+++ b/trex-scripts/tests/remote_pcap.py
@@ -21,14 +21,14 @@ class RemotePcap(StatelessTest):
             "--remote-pcap-file-dir",
             type=str,
             help="The directory which stores pcap files on the remove server.",
-            default="/"
+            default="/",
         )
         parser.add_argument(
             "--remote-pcap-files",
             type=str,
             help="The PCAP files which stores in remote server",
             required=True,
-            nargs="+"
+            nargs="+",
         )
         parser.add_argument(
             "--speed-multiplier", type=float, help="The speed multiplier", default=1
@@ -55,8 +55,7 @@ class RemotePcap(StatelessTest):
         )
 
         logging.info(
-            "Starting traffic, speedup: %f",
-            args.speed_multiplier,
+            "Starting traffic, speedup: %f", args.speed_multiplier,
         )
         for remote_pcap_file in args.remote_pcap_files:
             self.client.push_remote(


### PR DESCRIPTION
Allows users to replay multiple pcap files in order, for example:

```sh
./run-test.sh --trex-config trex-configs/4-ports-with-l2.yaml remote_pcap \
      --remote-pcap-file-dir /pcaps/ \
      --remote-pcap-files A.pcap B.pcap C.pcap
```