### PR TITLE
Update TOST setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,15 +64,15 @@ onos-logs:
 	@docker-compose -f tost/docker-compose.yaml logs -f
 
 onos-cli: tmp/keys/id_rsa
-	@ssh -o StrictHostKeyChecking=no -p 8101 -i tmp/keys/id_rsa $(USER)@127.0.0.1
+	@ssh -o StrictHostKeyChecking=no -p 18101 -i tmp/keys/id_rsa $(USER)@127.0.0.1
 
 onos-ui:
-	open http://127.0.0.1:8181/onos/ui
+	open http://127.0.0.1:18181/onos/ui
 
 netcfg:
 	@curl --fail -sSL --user onos:rocks --noproxy localhost \
 		-X POST -H 'Content-Type:application/json' \
-		http://localhost:8181/onos/v1/network/configuration -d@./tost/netcfg.json
+		http://localhost:18181/onos/v1/network/configuration -d@./tost/netcfg.json
 
 clean:
 	-rm -rf tmp

--- a/README.md
+++ b/README.md
@@ -203,6 +203,6 @@ For more information, check the [Trex stateless SDK manual](trex-stateless-sdk) 
 [trex-manual]: https://trex-tgn.cisco.com/trex/doc/trex_manual.html#_platform_yaml_cfg_argument
 [venv]: https://docs.python.org/3.8/library/venv.html
 [stratum-guide]: https://github.com/stratum/stratum/blob/master/stratum/hal/bin/barefoot/README.md
-[onos-ui]: http://127.0.0.1:8181/onos/ui
+[onos-ui]: http://127.0.0.1:18181/onos/ui
 [trex-stateless-sdk]: https://trex-tgn.cisco.com/trex/doc/cp_stl_docs/index.html
 [trex-cookbook]: https://trex-tgn.cisco.com/trex/doc/trex_cookbook/index.html

--- a/tost/docker-compose.yaml
+++ b/tost/docker-compose.yaml
@@ -5,11 +5,11 @@ version: "3"
 
 services:
   tost:
-    image: registry.aetherproject.org/tost/tost:1.0.2-b4
+    image: registry.aetherproject.org/tost/tost:stable-2021-02-08
     hostname: tost
     container_name: tost
     ports:
-      - "8181:8181" # HTTP
-      - "8101:8101" # SSH (CLI)
+      - "18181:8181" # HTTP
+      - "18101:8101" # SSH (CLI)
     environment:
       - ONOS_APPS=gui,drivers.barefoot,drivers.stratum,netcfghostprovider,org.stratumproject.fabric-tna,segmentrouting,inbandtelemetry


### PR DESCRIPTION
- Use 18181 and 18101 for ONOS ports since the 8181 port may conflict with
Rancher ingress services and it is hard to deploy this setup to servers
which already has Rancher k8s running
- Update TOST image