### PR TITLE
Fix `run-tests.sh` workspace directory, fix spelling and chassis config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ cd [trex root]/scripts
 sudo ./trex_daemon_server start[-live]
 ```
 
-Make sure the Trex service ports (4500, 4501, 4507, and 8090) are accessable from
+Make sure the Trex service ports (4500, 4501, 4507, and 8090) are accessible from
 the machine which runs test scripts.
 
 #### Set up a Stratum device

--- a/run-test.sh
+++ b/run-test.sh
@@ -27,11 +27,11 @@ while (( "$#" )); do
   esac
 done
 
-docker run --rm \
+docker run --rm -it \
            -v "${DIR}/trex-scripts:/workspace/trex-scripts" \
            -v "${DIR}/tools:/workspace/tools" \
            -v "${DIR}/tmp:/tmp" \
-           -w /workspace \
+           -w /workspace/trex-scripts \
            --mount "type=bind,source=$PWD/entrypoint.sh,target=/entrypoint.sh" \
            --entrypoint /entrypoint.sh \
            "${IMAGE}" \

--- a/stratum/chassis_config_with_port_shaping.pb.txt
+++ b/stratum/chassis_config_with_port_shaping.pb.txt
@@ -3,13 +3,13 @@
 
 description: "Chassis Config for Menlo PDP 32QS"
 chassis {
-platform: PLT_GENERIC_BAREFOOT_TOFINO
-name: "Edgecore Wedge100BF-32qs"
+  platform: PLT_GENERIC_BAREFOOT_TOFINO
+  name: "Edgecore Wedge100BF-32qs"
 }
 nodes {
-id: 1
-slot: 1
-index: 1
+  id: 1
+  slot: 1
+  index: 1
 }
 vendor_config {
   tofino_config {
@@ -17,17 +17,50 @@ vendor_config {
       key: 1
       value {
         per_port_shaping_configs {
-          key:30
+          key: 27
           value {
             byte_shaping {
-              max_rate_bps: 1000000000 # 1Gbps
-              max_burst_bytes: 160000 # 2x jumbo frame
+              rate_bps: 1000000000 # 1Gbps
+              burst_bytes: 160000 # 2x jumbo frame
+            }
+          }
+        }
+        per_port_shaping_configs {
+          key: 28
+          value {
+            byte_shaping {
+              rate_bps: 1000000000 # 1Gbps
+              burst_bytes: 160000 # 2x jumbo frame
             }
           }
         }
       }
     }
   }
+}
+singleton_ports {
+  id: 27
+  name: "27/0"
+  slot: 1
+  port: 27
+  channel: 1
+  speed_bps: 40000000000
+  config_params {
+    admin_state: ADMIN_STATE_ENABLED
+  }
+  node: 1
+}
+singleton_ports {
+  id: 28
+  name: "28/0"
+  slot: 1
+  port: 28
+  channel: 1
+  speed_bps: 40000000000
+  config_params {
+    admin_state: ADMIN_STATE_ENABLED
+  }
+  node: 1
 }
 singleton_ports {
   id: 29

--- a/trex-scripts/control.py
+++ b/trex-scripts/control.py
@@ -204,7 +204,7 @@ def main() -> int:
         try:
             logging.info("Connecting to Trex server...")
             trex_client.connect()
-            logging.info("Acquaring ports...")
+            logging.info("Acquiring ports...")
             trex_client.acquire()
             logging.info("Resetting and clearing port...")
             trex_client.reset()  # Resets configs from all ports


### PR DESCRIPTION
This PR changes the workspace directory of the docker container running a Trex test to `trex-scripts`, where the control.py scipt is. The test run now can be canceled by pressing CTRL+C. It also fixes a few spelling errors.